### PR TITLE
Targets an older C# version

### DIFF
--- a/CorgECS.Tests/CorgECS.Tests.csproj
+++ b/CorgECS.Tests/CorgECS.Tests.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\CorgECS.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/CorgECS.csproj
+++ b/CorgECS.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU;ARM32;ARM64</Platforms>
     <Authors>PowerfulBacon</Authors>

--- a/Worlds/World.cs
+++ b/Worlds/World.cs
@@ -38,7 +38,7 @@ namespace CorgECS.Worlds
 				}
 				else
 				{
-					T createdSystem = new();
+					T createdSystem = new T();
 					createdSystem.JoinWorld(this);
 					EntitySystems.Add(typeof(T), createdSystem);
 					return createdSystem;


### PR DESCRIPTION
Other programs such as unity do not support modern versions of C#. We need this downgrade so that we can use it inside of Unity. WIthout this we will recieve an error when trying to import it into Unity because Unity doesn't have .net Core 6 specific things such as the default string interpolation handler.